### PR TITLE
Remove granting private modules access step from release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,6 @@ on:
   push:
     tags: [ 'v*.*.*' ]
 
-env:
-  GOPRIVATE: https://github.com/paralus
-
 jobs:
 
   goreleaser:
@@ -31,10 +28,6 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go-version }}
-
-      - name: Granting private modules access
-        run: |
-          git config --global url."https://${{ secrets.TOKEN }}:x-oauth-basic@github.com/paralus".insteadOf "https://github.com/paralus"
 
       - name: vendor packages
         run: go mod tidy && go mod vendor


### PR DESCRIPTION
### What does this PR change?
- Remove granting private modules access step from release pipeline

### Does the PR depend on any other PRs or Issues? If yes, please list them.
NONE

### Checklist

I confirm, that I have...

- [X] Read and followed the contributing guide in `CONTRIBUTING.md`
- [ ] Added tests for this PR
- [X] Formatted the code using `go fmt` (if applicable)
- [ ] Updated [documentation on the Paralus docs site](https://github.com/paralus/website/blob/main/docs) (if applicable)
- [ ] Updated `CHANGELOG.md`
