### PR TITLE
Fix download kubeconfig error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+- Fix kubeconfig download error from [akshay196](https://github.com/akshay196)
+
 ### Added
 ### Changed
 ### Fixed

--- a/cmd/kubeconfig.go
+++ b/cmd/kubeconfig.go
@@ -40,9 +40,9 @@ var KubeconfigDownloadCmd = &cobra.Command{
 		}
 		if cluster != "" {
 			params.Add("opts.selector", fmt.Sprintf("paralus.dev/clusterName=%s", cluster))
-			params.Add("opts.ID", config.GetConfig().APIKey)
-			params.Add("opts.organization", config.GetConfig().Organization)
 		}
+		params.Add("opts.ID", config.GetConfig().APIKey)
+		params.Add("opts.organization", config.GetConfig().Organization)
 
 		uri := fmt.Sprintf("/v2/sentry/kubeconfig/user?%s", params.Encode())
 		resp, err := auth.AuthAndRequestFullResponse(uri, "GET", nil)


### PR DESCRIPTION
### What does this PR change?
Fix an error when download kubeconfig without `--cluster` flag.
```
$ ./pctl kubeconfig download --config ./admin@paralus.local.json
Error: failed to get kubeconfig [Err = server error [return code: 503]: upstream connect error or disconnect/reset before headers. reset reason: connection termination ]
```

### Does the PR depend on any other PRs or Issues? If yes, please list them.
NONE

### Checklist

I confirm, that I have...

- [X] Read and followed the contributing guide in `CONTRIBUTING.md`
- [] Added tests for this PR
- [X] Formatted the code using `go fmt` (if applicable)
- [X] Updated [documentation on the Paralus docs site](https://github.com/paralus/website/blob/main/docs) (if applicable)
- [X] Updated `CHANGELOG.md`
