### PR TITLE
Update GoReleaser config and CI pipelines

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -6,15 +6,11 @@ on:
   pull_request:
     branches: [ main ]
 
-env:
-  GOPRIVATE: https://github.com/paralus
-
 jobs:
 
   test:
     strategy:
       matrix:
-        go-version: [1.17.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -23,14 +19,13 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: ${{ matrix.go-version }}
+          # Getting go version from the go.mod file
+          go-version-file: 'go.mod'
 
-      - name: Format
+      - run: go version
+
+      - name: Check code format
         run: if [ "$(gofmt -s -l . | wc -l)" -gt 0 ]; then exit 1; fi
-
-      - name: Granting private modules access
-        run: |
-          git config --global url."https://${{ secrets.TOKEN }}:x-oauth-basic@github.com/paralus".insteadOf "https://github.com/paralus"
 
       - name: Test all
         run: go test -v ./...
@@ -38,7 +33,6 @@ jobs:
   # golangci:
   #   strategy:
   #     matrix:
-  #       go-version: [1.17.x]
   #       os: [ubuntu-latest]
   #   runs-on: ${{ matrix.os }}
   #   steps:
@@ -47,11 +41,10 @@ jobs:
   #     - name: Set up Go
   #       uses: actions/setup-go@v4
   #       with:
-  #         go-version: ${{ matrix.go-version }}
+  #         # Getting go version from the go.mod file
+  #         go-version-file: 'go.mod'
 
-  #     - name: Granting private modules access
-  #       run: |
-  #         git config --global url."https://${{ secrets.TOKEN }}:x-oauth-basic@github.com/paralus".insteadOf "https://github.com/paralus"
+  #     - run: go version
 
   #     - name: golangci-lint
   #       uses: golangci/golangci-lint-action@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,49 +1,56 @@
-name: goreleaser
+name: GoReleaser
 
 on:
   push:
+    branches: [ main ]
     tags: [ 'v*.*.*' ]
-    
+
 permissions:
   contents: write
 
 jobs:
 
-  goreleaser:
+  release:
     strategy:
       matrix:
-        go-version: [1.17.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
-    permissions:
-      contents: write
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
-          fetch-depth: 0
+          fetch-depth: 0 # It is required for GoReleaser to work properly.
 
+      # This is needed if you use fields like TagBody, TagSubject or
+      # TagContents in your templates.
       - name: Fetch all tags
         run: git fetch --force --tags
 
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: ${{ matrix.go-version }}
+          # Getting go version from the go.mod file
+          go-version-file: 'go.mod'
 
-      - name: vendor packages
-        run: go mod tidy -compat=1.17 && go mod vendor
+      - run: go version
 
       # Sanity check before publishing
       - name: Test all
         run: go test -v ./...
+
+      - name: Set goreleaser snapshot env
+        run: if [[ $GITHUB_REF != refs/tags/v* ]]; then echo "goreleaser_snapshot=--snapshot"; fi >> $GITHUB_ENV
+
+      - name: Read variables
+        run: |
+          echo "goreleaser_snapshot=${{ env.goreleaser_snapshot }}"
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@f82d6c1c344bcacabba2c841718984797f664a6b # V4.2.0
         with:
           distribution: goreleaser
           version: latest
-          args: release --rm-dist
+          args: release --clean ${{ env.goreleaser_snapshot }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [ main ]
     tags: [ 'v*.*.*' ]
+  pull_request:
+    branches: [ main ]
 
 permissions:
   contents: write

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,12 +1,10 @@
-# This is an example .goreleaser.yml file with some sensible defaults.
-# Make sure to check the documentation at https://goreleaser.com
+# Check the documentation at https://goreleaser.com
 project_name: pctl
+
 before:
   hooks:
-    # You may remove this if you don't use go modules.
-    - go mod tidy -compat=1.17
-    # you may remove this if you don't need go generate
-    - go generate ./...
+    - go mod tidy
+
 builds:
   - env:
       - CGO_ENABLED=0
@@ -18,15 +16,28 @@ builds:
       - -s -w -X main.version={{.Version}} -X main.time={{.CommitTimestamp }} -X main.buildNum={{.Version}}
 
 archives:
-  - replacements:
-      386: i386
+  - name_template: >-
+      {{ .ProjectName }}_
+      {{- .Version }}_
+      {{- .Os }}_
+      {{- if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+    format_overrides:
+    - goos: windows
+      format: zip
+
 checksum:
   name_template: 'checksums.txt'
+
 snapshot:
   name_template: "{{ incpatch .Version }}-next"
+
 changelog:
   sort: asc
+  use: github
   filters:
     exclude:
       - '^docs:'
       - '^test:'
+      - '^chore'
+      - Merge pull request

--- a/go.mod
+++ b/go.mod
@@ -1,45 +1,28 @@
 module github.com/paralus/cli
 
-go 1.17
-
-require github.com/spf13/cobra v1.3.0
-
-require go.uber.org/zap v1.21.0
-
-require github.com/tidwall/gjson v1.14.0
-
-require (
-	github.com/oliveagle/jsonpath v0.0.0-20180606110733-2e52cf6e6852
-	github.com/segmentio/encoding v0.3.4
-	gopkg.in/yaml.v2 v2.4.0
-)
-
-require github.com/go-openapi/runtime v0.23.1
+go 1.20
 
 require (
 	github.com/ghodss/yaml v1.0.0
+	github.com/go-openapi/runtime v0.23.1
 	github.com/levigross/grequests v0.0.0-20190908174114-253788527a1a
-)
-
-require (
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
-	github.com/spacemonkeygo/httpsig v0.0.0-20181218213338-2605ae379e47
-	github.com/stretchr/testify v1.7.0
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
-)
-
-require (
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/spf13/viper v1.10.1
-)
-
-require github.com/olekukonko/tablewriter v0.0.5
-
-require (
+	github.com/olekukonko/tablewriter v0.0.5
+	github.com/oliveagle/jsonpath v0.0.0-20180606110733-2e52cf6e6852
 	github.com/ory/kratos-client-go v0.11.1
 	github.com/paralus/paralus v0.1.10-0.20230127131419-80f7a148b0b6
+	github.com/segmentio/encoding v0.3.4
+	github.com/spacemonkeygo/httpsig v0.0.0-20181218213338-2605ae379e47
+	github.com/spf13/cobra v1.3.0
 	github.com/spf13/pflag v1.0.5
+	github.com/spf13/viper v1.10.1
+	github.com/stretchr/testify v1.7.0
+	github.com/tidwall/gjson v1.14.0
+	go.uber.org/zap v1.21.0
 	golang.org/x/term v0.6.0
+	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 )
 
 require (

--- a/pkg/output/exit.go
+++ b/pkg/output/exit.go
@@ -9,13 +9,14 @@ import (
 	"github.com/paralus/cli/pkg/log"
 )
 
-/* This function exits the pctl program. In case 'exit' is not set,
-   nothing will be printed to the console. The return code of
-   program is set to zero.
+/*
+This function exits the pctl program. In case 'exit' is not set,
+nothing will be printed to the console. The return code of program is
+set to zero.
 
-   When 'exit' is set, the exit message will be printed to
-   the console before the program exits with the return code
-   set in the 'exit' structure.
+When 'exit' is set, the exit message will be printed to the console
+before the program exits with the return code set in the 'exit'
+structure.
 */
 func Exit() {
 	e := exit.Get()


### PR DESCRIPTION
### What does this PR change?

* Use Go 1.20
* GoReleaser config update
   - Remove deprecated archives.replacements from goreleaser config
   - Zip archives for Windows
   - Run goreleaser for main branch and pull requests
* Go CI update
   - Remove Go private module step
   - Get go version from go.mod file

### Does the PR depend on any other PRs or Issues? If yes, please list them.

None

### Checklist

I confirm, that I have...

- [x] Read and followed the contributing guide in `CONTRIBUTING.md`
- [x] Added tests for this PR
- [x] Formatted the code using `go fmt` (if applicable)
- [x] Updated [documentation on the Paralus docs site](https://github.com/paralus/website/blob/main/docs) (if applicable)
- [x] Updated `CHANGELOG.md`
