### PR TITLE
Fix/user validation error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor/
 dist/
+admin@paralus.local.json

--- a/pkg/commands/create_user.go
+++ b/pkg/commands/create_user.go
@@ -41,7 +41,7 @@ func (o *CreateUserOptions) Run(cmd *cobra.Command, args []string) error {
 	Username := args[0]
 
 	if !strings.Contains(Username, "@") || !strings.Contains(Username, ".") {
-    return fmt.Errorf("invalid email format: expected something like user@example.com")
+		return fmt.Errorf("invalid email format: expected something like user@example.com")
 	}
 	err := CreateUser(cmd, Username, o.Groups, o.ConsoleAccessInputs)
 	if err != nil {

--- a/pkg/commands/create_user.go
+++ b/pkg/commands/create_user.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/paralus/cli/pkg/config"
 	"github.com/paralus/cli/pkg/group"
@@ -39,6 +40,9 @@ func (o *CreateUserOptions) Run(cmd *cobra.Command, args []string) error {
 
 	Username := args[0]
 
+	if !strings.Contains(Username, "@") || !strings.Contains(Username, ".") {
+    return fmt.Errorf("invalid email format: expected something like user@example.com")
+	}
 	err := CreateUser(cmd, Username, o.Groups, o.ConsoleAccessInputs)
 	if err != nil {
 		return err

--- a/pkg/user/user.go
+++ b/pkg/user/user.go
@@ -69,7 +69,7 @@ func CreateUser(usr *userv3.User) error {
 	uri := "/auth/v3/users"
 	resp, err := auth.AuthAndRequest(uri, "POST", usr)
 	if err != nil {
-		return err
+		return fmt.Errorf("user creation failed: %v", err)
 	}
 	var ur userv3.User
 	if err := json.Unmarshal([]byte(resp), &ur); err != nil {


### PR DESCRIPTION
### What does this PR change?

Improves validation and error handling for `pctl create user`.

## Changes
- Added email format validation before API call
- Improved error handling to surface actual backend error instead of misleading 500

## Result
- Invalid input like `pctl create user abc` now returns:
  "invalid email format"
- Backend errors are displayed clearly

## Context
While reproducing issue #310, it was observed that:
- CLI allowed invalid input
- Backend returned 400 but CLI showed 500

This change improves UX and debugging clarity.


### Does the PR depend on any other PRs or Issues? If yes, please list them.

- Issue #310 

### Checklist

I confirm, that I have...

- [ .] Read and followed the contributing guide in `CONTRIBUTING.md`
- [ ] Added tests for this PR
- [ .] Formatted the code using `go fmt` (if applicable)
- [ ] Updated [documentation on the Paralus docs site](https://github.com/paralus/website/blob/main/docs) (if applicable)
- [ ] Updated `CHANGELOG.md`
